### PR TITLE
Maintain cloze class in converted markdown

### DIFF
--- a/src/inka/models/highlighter.py
+++ b/src/inka/models/highlighter.py
@@ -9,7 +9,7 @@ from .anki_api import AnkiApi
 from .anki_media import AnkiMedia
 from .notes.note import Note
 
-HLJS_VERSION = "10.7.1"
+HLJS_VERSION = "11.4.0"
 BASE_URL = f"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/{HLJS_VERSION}"
 
 # Thanks u/arthurmilchior for the initial idea.
@@ -20,11 +20,28 @@ function color() {
     if (typeof hljs !== 'undefined') {
         codes = document.querySelectorAll(selector)
         codes.forEach(element => {
+            recloze = uncloze(element);
             hljs.highlightBlock(element);
+            recloze();
         });
     } else {
         setTimeout(color, 50)
     }
+}
+function uncloze(el) {
+    let html = el.innerHTML;
+    const clozes = el.querySelectorAll(".cloze");
+    clozes.forEach(
+        (c, i) => (html = html.replace(c.outerHTML, `__CLOZE__${i}`))
+    );
+    el.innerHTML = html;
+    return function () {
+        let html = el.innerHTML;
+        clozes.forEach(
+            (c, i) => (html = html.replace(`__CLOZE__${i}`, c.outerHTML))
+        );
+        el.innerHTML = html;
+    };
 }
 color()
 </script>"""


### PR DESCRIPTION
Inka is a great tool—thanks so much for making it!

I hope you'll consider this PR, which:

- Bumps the HLJS version (notably, this correctly highlights f-strings in Python)
- Maintains the `.cloze` class on cloze deletions, allowing them to be styled. Currently this information is lost when highlighted so you cannot make them a different color or font, for example. If there are no clozes this just no-ops, so it's suitable for the regular card type too. I figured that was simpler than introducing separate script blocks for cloze vs regular.

Happy to rework this if you think it needs some changes, or if this isn't a feature you agree with, I understand.